### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -306,7 +306,7 @@
       uses: docker/setup-buildx-action@v2
 
     - name: Publish Docker Image
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: edgedb/edgedb
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2349,7 +2349,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Publish Docker Image
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: edgedb/edgedb
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2277,7 +2277,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Publish Docker Image
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: edgedb/edgedb
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2367,7 +2367,7 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Publish Docker Image
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: edgedb/edgedb
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore